### PR TITLE
add KL divergence measure between policies before/after the param update

### DIFF
--- a/pfrl/agents/goal_conditioned_td3.py
+++ b/pfrl/agents/goal_conditioned_td3.py
@@ -270,8 +270,9 @@ class GoalConditionedTD3(TD3, GoalConditionedBatchAgent):
         action_distrib = self.policy(torch.cat([batch_state, batch_goal], -1))
         target_action_distrib = self.target_policy(torch.cat([batch_state, batch_goal], -1))
 
-        self.kl_divergence = float(torch.distributions.kl.kl_divergence(
-            action_distrib, target_action_distrib))
+        if self.add_entropy:
+            self.kl_divergence = float(torch.distributions.kl.kl_divergence(
+                action_distrib, target_action_distrib))
 
     def sample_if_possible(self):
         sample = self.replay_updater.can_update_then_sample(self.t)

--- a/pfrl/agents/hrl/hiro_agent.py
+++ b/pfrl/agents/hrl/hiro_agent.py
@@ -273,6 +273,7 @@ class HIROAgent(HRLAgent):
             ("low_con_policy_gradients_mean", _mean_or_nan(self.low_con.agent.policy_gradients_mean_record)),
             ("low_con_policy_n_updates", self.low_con.agent.policy_n_updates),
             ("low_con_q_func_n_updates", self.low_con.agent.q_func_n_updates),
+            ("low_con_policy_update_kldivergence", self.low_con.agent.kl_divergence),
 
             ("high_con_average_q1", _mean_or_nan(self.high_con.agent.q1_record)),
             ("high_con_average_q2", _mean_or_nan(self.high_con.agent.q2_record)),
@@ -285,6 +286,7 @@ class HIROAgent(HRLAgent):
             ("high_con_policy_gradients_mean", _mean_or_nan(self.high_con.agent.policy_gradients_mean_record)),
             ("high_con_policy_n_updates", self.high_con.agent.policy_n_updates),
             ("high_con_q_func_n_updates", self.high_con.agent.q_func_n_updates),
+            ("high_con_policy_update_kldivergence", self.high_con.agent.kl_divergence),
             ("final_x", self.last_x),
             ('final_y', self.last_y),
             ('final_z', self.last_z)

--- a/pfrl/agents/hrl/hiro_agent.py
+++ b/pfrl/agents/hrl/hiro_agent.py
@@ -274,6 +274,7 @@ class HIROAgent(HRLAgent):
             ("low_con_policy_n_updates", self.low_con.agent.policy_n_updates),
             ("low_con_q_func_n_updates", self.low_con.agent.q_func_n_updates),
             ("low_con_policy_update_kldivergence", self.low_con.agent.kl_divergence),
+            ("low_con_policy_update_one_step_kldivergence", self.low_con.agent.one_step_kl_divergence),
 
             ("high_con_average_q1", _mean_or_nan(self.high_con.agent.q1_record)),
             ("high_con_average_q2", _mean_or_nan(self.high_con.agent.q2_record)),

--- a/pfrl/explorers/additive_gaussian.py
+++ b/pfrl/explorers/additive_gaussian.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import torch
 from pfrl import explorer
 
 
@@ -22,6 +22,14 @@ class AdditiveGaussian(explorer.Explorer):
         self.scale = scale
         self.low = low
         self.high = high
+
+    def distribution(self, x):
+        base_distribution = torch.distributions.Independent(
+            torch.distributions.Normal(loc=x, scale=self.scale), 1
+        )
+        return torch.distributions.transformed_distribution.TransformedDistribution(
+            base_distribution, [torch.distributions.transforms.TanhTransform(cache_size=1)]
+        )
 
     def select_action(self, t, greedy_action_func, action_value=None):
         a = greedy_action_func()


### PR DESCRIPTION
# Change
- Added a KL divergence measure to quantify "how different are the policies before/after the policy gradient update"


This should help us to understand why lower controller without entropy works well and why adding entropy breaks the training