### PR TITLE
change num units

### DIFF
--- a/pfrl/agents/hrl/hrl_controllers.py
+++ b/pfrl/agents/hrl/hrl_controllers.py
@@ -70,11 +70,11 @@ class HRLControllerBase():
 
             # SAC policy definition:
             policy = nn.Sequential(
-                nn.Linear(state_dim + goal_dim, 256),
+                nn.Linear(state_dim + goal_dim, 300),
                 nn.ReLU(),
-                nn.Linear(256, 256),
+                nn.Linear(300, 300),
                 nn.ReLU(),
-                nn.Linear(256, action_dim * 2),
+                nn.Linear(300, action_dim * 2),
                 Lambda(squashed_diagonal_gaussian_head),
                 )
 


### PR DESCRIPTION
Changes number of hidden units in the entropy-based agents from 256 to 300 to align with TD3.