### PR TITLE
Get rid of constant mult in the architecture of the deterministic policy

### DIFF
--- a/pfrl/agents/hrl/hrl_controllers.py
+++ b/pfrl/agents/hrl/hrl_controllers.py
@@ -93,7 +93,6 @@ class HRLControllerBase():
                 nn.ReLU(),
                 nn.Linear(300, action_dim),
                 nn.Tanh(),
-                ConstantsMult(self.scale_tensor),
                 pfrl.policies.DeterministicHead(),
                 )
             # TODO - have proper low and high values from action space.


### PR DESCRIPTION
This PR gets rid of the constant multiplier in the architecture of the deterministic policy because it's taken care of in another file.